### PR TITLE
Don't use audio mapping with level values (just use raw level value)

### DIFF
--- a/client/components/audiofader/audiofader.coffee
+++ b/client/components/audiofader/audiofader.coffee
@@ -7,13 +7,11 @@ class AudioFader
 
   setLevel: (level) ->
     if @sliderRendered and @allowUpdate
-      level = @_mapValue level
       @tmpl.$('input').slider 'setValue', level
     level
 
   getLevel: ->
-    slider = @tmpl.$('input').slider 'getValue'
-    @_unmapValue slider
+    @tmpl.$('input').slider 'getValue'
 
   saveLevel: ->
     _id = Template.parentData(1)._id


### PR DESCRIPTION
The state of audio handling in Peakaboo and the Galicaster plugin isn't great or very flexible. Handling the sending of min and max db values for a mixer requires them to be set in the Galicaster plugin (ideally this should be automated) and the reason for this is because `alsaaudio`'s `mixer.getvolume()` method returns values in a different format than `alsamixer` so for it to be consistent there is some conversion/mapping required.
I've experienced issues with the `alsaaudio` package reading volume levels for various mixers and have resorted to making `amixer` calls (far from ideal) to get/set the volume for mixers, negating the need to send the min/max values at all.
Audio still needs quite a bit of work in Peakaboo and the associated plugin, but I'm happy to share what I've done in terms of plugin changes for this.