### PR TITLE
Remove HEAD from limit_except directive in nginx.conf.

### DIFF
--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -43,7 +43,8 @@ http {
         location /image/ {
             include /etc/nginx/peakaboo-proxy.conf;
             proxy_pass http://peakaboo/image/;
-            limit_except GET HEAD {
+            # Allowing the GET method makes the HEAD method also allowed.
+            limit_except GET { 
                 auth_basic 'go away';
                 auth_basic_user_file /etc/nginx/.htpasswd;
             }


### PR DESCRIPTION
Removing unnecessary http method. HEAD is implicit when GET is present.

For further reading about this from the nginx docs: <http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except>